### PR TITLE
Fix bug of unrecognized name-value

### DIFF
--- a/.github/workflows/main-ci.yml
+++ b/.github/workflows/main-ci.yml
@@ -29,5 +29,5 @@ jobs:
       # uses: codecov/codecov-action@239febf655bba88b16ff5dea1d3135ea8663a1f9
       uses: codecov/codecov-action@v1.0.15
       with:
-        token: ${{ secret.CODECOV_TOKEN }}
+        token: ${{ secrets.CODECOV_TOKEN }}
         env_vars: ${{ matrix.node-version }}


### PR DESCRIPTION
This commit is to fix the bug of broken the CI pipeline on main branch for unrecognized name-value error.

CLOSE:#9